### PR TITLE
manifest: Track external/tinyxml

### DIFF
--- a/404.xml
+++ b/404.xml
@@ -64,6 +64,7 @@
   <project path="external/libjpeg-turbo" name="android_external_libjpeg-turbo" remote="404" />
   <remove-project name="platform/external/sqlite" />
   <project path="external/sqlite" name="android_external_sqlite" remote="404" />
+  <project path="external/tinyxml" name="android_external_tinyxml" remote="404" />
   <remove-project name="platform/external/zlib" />
   <project path="external/zlib-ng" name="android_external_zlib-ng" remote="404" />
 


### PR DESCRIPTION
* It is dropped in A12, but some blobs still need it

Change-Id: I6b7a7265d6e67f486c2639e747b24bd00a6d5314
Signed-off-by: Ratoriku <a1063021545@gmail.com>