### PR TITLE
Remove dialer duplicate and use the 404 one

### DIFF
--- a/404.xml
+++ b/404.xml
@@ -113,8 +113,6 @@
   <project path="packages/apps/ExactCalculator" name="android_packages_apps_ExactCalculator" remote="404" />
   <remove-project name="platform/packages/apps/Messaging" />
   <project path="packages/apps/Messaging" name="android_packages_apps_Messaging" remote="404" caf="platform/packages/apps/Messaging" />
-  <remove-project name="platform/packages/apps/Dialer" />
-  <project path="packages/apps/Dialer" name="android_packages_apps_Dialer" remote="404" caf="platform/packages/apps/Dialer" />
   <remove-project name="platform/packages/apps/Contacts" />
   <project path="packages/apps/Contacts" name="android_packages_apps_Contacts" remote="404" caf="platform/packages/apps/Contacts" />
   <remove-project name="platform/packages/apps/SettingsIntelligence" />


### PR DESCRIPTION
Remove dialer should fix the duplicate packages error while building.
It give the duplicate packages error with the dialer of CAF